### PR TITLE
Update MMM-TextClock.js

### DIFF
--- a/MMM-TextClock.js
+++ b/MMM-TextClock.js
@@ -13,6 +13,7 @@ Module.register("MMM-TextClock",{
 		to24: "BLOODY", //text between hour and minute
 		after24: "ALREADY?", //text after minute
 		marked: "color: white; font-weight: 400;", //css code to mark current time in Field layout
+		offset: 0 //offset in minutes when to change to next text (0 = late; 2 = fuzzy; 5 = early)
 	},
 
 	getScripts: function() {
@@ -44,7 +45,7 @@ Module.register("MMM-TextClock",{
 	getDom: function() {
 		var wrapper = document.createElement("div");
 		// set up moment and variables for the clock
-		var now = moment();
+    		var now = moment().add(this.config.offset, "m"); // add offset in Minutes
 		var hourSymbol = "HH";
 		if (this.config.timeFormat !== 24) { hourSymbol = "h";		}
 		timeMinute = now.format("mm");


### PR DESCRIPTION
This lets the user decide how the time should be interpreted into text:
offset: 0, // late: show the text as soon as the five-minute interval has passed
offset: 5, // early: show the text as soon as the five-minute interval starts
offset: 2, // fuzzy: change the time a little earlier (any value possible; in minutes)